### PR TITLE
Allow initializing keyed children

### DIFF
--- a/lib/opto/model/association/has_many/declaration.rb
+++ b/lib/opto/model/association/has_many/declaration.rb
@@ -37,6 +37,16 @@ module Opto
                     end
                   end
                   self.send(relation).members
+                elsif args.kind_of?(Hash)
+                  self.send(relation).clear
+                  args.each do |k,v|
+                    if v.kind_of?(Hash)
+                      self.send(relation).new(k => v)
+                    else
+                      raise TypeError, "Expected an instance of Hash"
+                    end
+                  end
+                  self.send(relation).members
                 elsif args.nil?
                   self.send(relation).clear
                 else

--- a/lib/opto/model/association/has_many/proxy.rb
+++ b/lib/opto/model/association/has_many/proxy.rb
@@ -57,7 +57,7 @@ module Opto
             result.empty? ? {} : { as => result }
           end
 
-          def_delegators :members, *::Array.instance_methods - [:__send__, :object_id, :to_h]
+          def_delegators :members, *::Array.instance_methods - [:__send__, :object_id, :to_h, :__id__]
         end
       end
     end

--- a/lib/opto/model/association/has_many/proxy.rb
+++ b/lib/opto/model/association/has_many/proxy.rb
@@ -8,7 +8,8 @@ module Opto
           extend Forwardable
 
           def initialize(parent, target_class, as, options = {})
-            @parent, @target_class, @as, @options = parent, target_class, as, options
+            @parent, @target_class, @as = parent, target_class, as
+            @options = { key_is: :name }.merge(options)
             @members = []
           end
 
@@ -33,6 +34,10 @@ module Opto
           end
 
           def new(*args)
+            if args.first.kind_of?(Hash) && args.size == 1 && args.first[args.first.keys.first].kind_of?(Hash)
+              key = args.first.keys.first
+              args = [args.first[key].merge(options[:key_is] => key)]
+            end
             target = target_class.new(*args)
             members << target
             target

--- a/lib/opto/model/association/has_many/proxy.rb
+++ b/lib/opto/model/association/has_many/proxy.rb
@@ -36,7 +36,7 @@ module Opto
           def new(*args)
             if args.first.kind_of?(Hash) && args.size == 1 && args.first[args.first.keys.first].kind_of?(Hash)
               key = args.first.keys.first
-              args = [args.first[key].merge(options[:key_is] => key)]
+              args = [args.first[key].merge(options[:key_is] => key.kind_of?(Symbol) ? key.to_s : key)]
             end
             target = target_class.new(*args)
             members << target

--- a/lib/opto/model/association/has_one/proxy.rb
+++ b/lib/opto/model/association/has_one/proxy.rb
@@ -8,7 +8,8 @@ module Opto
           extend Forwardable
 
           def initialize(parent, target_class, as, target = nil, options = {})
-            @parent, @target_class, @as, @target, @options = parent, target_class, as, target, options
+            @parent, @target_class, @as, @target = parent, target_class, as, target
+            @options = { key_is: :name }.merge(options)
           end
 
           def association_errors
@@ -32,6 +33,10 @@ module Opto
           end
 
           def new(*args)
+            if args.first.kind_of?(Hash) && args.size == 1 && args.first[args.first.keys.first].kind_of?(Hash)
+              key = args.first.keys.first
+              args = [args.first[key].merge(options[:key_is] => key)]
+            end
             @target = target_class.new(*args)
           end
 

--- a/lib/opto/model/association/has_one/proxy.rb
+++ b/lib/opto/model/association/has_one/proxy.rb
@@ -35,7 +35,7 @@ module Opto
           def new(*args)
             if args.first.kind_of?(Hash) && args.size == 1 && args.first[args.first.keys.first].kind_of?(Hash)
               key = args.first.keys.first
-              args = [args.first[key].merge(options[:key_is] => key)]
+              args = [args.first[key].merge(options[:key_is] => key.kind_of?(Symbol) ? key.to_s : key)]
             end
             @target = target_class.new(*args)
           end

--- a/spec/opto/association_spec.rb
+++ b/spec/opto/association_spec.rb
@@ -13,6 +13,7 @@ describe Opto::Model do
           include Opto::Model
 
           attribute :foo, :string
+          attribute :name, :string, required: false
 
           has_one :friend, AssocTestModel, required: true
           has_many :friends, AssocTestModel, required: true
@@ -52,6 +53,14 @@ describe Opto::Model do
         instance = assoc_test_model.new(friend: { foo: 'bar' })
         expect(instance.friend).to be_kind_of(assoc_test_model)
         expect(instance.friend.foo).to eq 'bar'
+        expect(instance.friend.name).to be_nil
+      end
+
+      it 'can initialize named has_one children' do
+        instance = assoc_test_model.new(friend: { baz: { foo: 'bar' }})
+        expect(instance.friend).to be_kind_of(assoc_test_model)
+        expect(instance.friend.foo).to eq 'bar'
+        expect(instance.friend.name).to eq 'baz'
       end
 
       it 'can initialize has_many children' do
@@ -60,6 +69,16 @@ describe Opto::Model do
         expect(instance.friends.size).to eq 2
         expect(instance.friends.first.foo).to eq 'bar'
         expect(instance.friends.last.foo).to eq 'baz'
+      end
+
+      it 'can initialize named has_many children' do
+        instance = assoc_test_model.new(friends: { baz: {foo: 'bar' }, buz: {foo: 'baz'} })
+        expect(instance.friends.first).to be_kind_of(assoc_test_model)
+        expect(instance.friends.size).to eq 2
+        expect(instance.friends.first.foo).to eq 'bar'
+        expect(instance.friends.last.foo).to eq 'baz'
+        expect(instance.friends.first.name).to eq 'baz'
+        expect(instance.friends.last.name).to eq 'buz'
       end
 
       it 'can clear an association' do


### PR DESCRIPTION
Before:

```ruby
class Foo
  attribute :name, :string
  attribute :nickname, :string
  has_many :friends, Foo
end
Foo.new(friends: [ {name: "john", nickname: 'johnnie'}, {name: "william", nickname: "bill" } ])
```

After:

```ruby
class Foo
  attribute :name, :string
  attribute :nickname, :string
  has_many :friends, Foo, key_is: :nickname # (default is :name)
end
f = Foo.new(friends: { dick: {name: "richard"}, bill: {name: "william"} ])
f.friends.first.nickname
=> 'dick'
f.friends.first.name
=> 'richard'
```
